### PR TITLE
remove call to nvidia-smi in build

### DIFF
--- a/Wrappers/Python/conda-recipe/build.sh
+++ b/Wrappers/Python/conda-recipe/build.sh
@@ -6,5 +6,5 @@ cp -v ${RECIPE_DIR}/../setup.py ${SRC_DIR}/ccpi
 
 cd ${SRC_DIR}/ccpi
 echo "Python command is ${PYTHON}"
-nvidia-smi
+
 ${PYTHON} setup.py install


### PR DESCRIPTION
this will likely fail to work in a machine without GPU